### PR TITLE
fix: datetime import error on Python <3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 timewarrior extension that prints the total length of time spent on each of the selected tags in the selected time frame.
 
+## Prerequisites
+
+* Python >= 3.9
+
 ## Installation
 
 ```console

--- a/tagsum.py
+++ b/tagsum.py
@@ -10,7 +10,7 @@ timew report tagsum [range] [tag]
 timew tagsum [range] [tag]
 """
 
-from datetime import datetime, timedelta, UTC, timezone
+from datetime import datetime, timedelta, timezone
 import json
 from sys import stdin
 
@@ -97,7 +97,7 @@ def convert_timestamps(data: list[dict[str, str]], rep_start: str, rep_end: str)
             rep_start
         )
         entry["end"] = (
-            datetime.now(UTC)
+            datetime.now(timezone.utc)
             if entry.get("end") is None
             else min(
                 datetime.strptime(entry["end"], DATETIME_FORMAT).replace(


### PR DESCRIPTION
This commit fixes an issue introduced with #2 that caused the script to fail when using Python versions <3.11. The reason for this was the usage of the `datetime.UTC` alias for `datetime.timezone.utc` which was only introduced in Python 3.11. This alias is now no longer used.

Fixes #4